### PR TITLE
Fix string interpolation after escape

### DIFF
--- a/syntaxes/packer.json
+++ b/syntaxes/packer.json
@@ -698,7 +698,7 @@
     },
     "string_interpolation": {
       "name": "meta.interpolation.hcl",
-      "begin": "(\\G|[^%$])([%$]{)",
+      "begin": "(?<!\\G|[%$])([%$]{)",
       "end": "\\}",
       "comment": "String interpolation",
       "beginCaptures": {


### PR DESCRIPTION
Currently, when you put a escape character before a string intepolation expression in a string, the interpolation is not highlighted:

![image](https://github.com/mondeja/vscode-packer-powertools/assets/23049315/83c9e322-ff08-4251-9c16-8fde7862ef99)

After this patch, is working as expected:

![image](https://github.com/mondeja/vscode-packer-powertools/assets/23049315/9b93a6bf-ebda-4d98-a27b-b4dd38188155)

Check [`hashicorp.terraform`](https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform) extension syntax, is using this approach.